### PR TITLE
fix upnl calc on linear contracts

### DIFF
--- a/Public-Contract-API-en.md
+++ b/Public-Contract-API-en.md
@@ -683,7 +683,7 @@ GET /accounts/accountPositions?currency=<currency>
 ```
 Inverse contract: unRealizedPnl = (posSize/contractSize) / avgEntryPrice - (posSize/contractSize) / markPrice)
 
-Linear contract:  unRealizedPnl = (posSize/contractSize) * markPrice - (posSize/contractSize) * avgEntryPrice
+Linear contract:  unRealizedPnl = (posSize*contractSize) * markPrice - (posSize*contractSize) * avgEntryPrice
 
 posSize is a signed vaule. contractSize is a fixed value.
 


### PR DESCRIPTION
When using the contractSize from the API endpoint `/public/products` (ETH=0.005) you need to multiply instead.