### PR TITLE
AS-769: marketDataUser group ratelimit description

### DIFF
--- a/Generic-API-Info.en.md
+++ b/Generic-API-Info.en.md
@@ -91,8 +91,8 @@
 
    * marketDataUser group
 
-<a name="marketDataUser"/>
-   marketDataUser group is for public kline and other market data related APIs, which contains following published api.
+<a name="marketDataGroup"/>
+   MarketData group is for public kline and other market data related APIs, which contains following published api.
 
 | Path | Method | Weight | Description |
 |------|--------|--------|-------------|

--- a/Generic-API-Info.en.md
+++ b/Generic-API-Info.en.md
@@ -50,6 +50,7 @@
    |------------|---------|
    | Contract   |  500/minute |
    | SpotOrder  |  500/minute |
+   | marketDataUser  |  100/minute |
    | Others     |  100/minute |
 
 
@@ -87,6 +88,15 @@
 | /spot/orders/all | DELETE | 2 | Cancel spot orders by symbol |
 | /spot/orders/active | GET | 1 | Query open spot order |
 | /spot/orders | GET | 1 | Query all open spot orders by symbol |
+
+   * marketDataUser group
+
+<a name="marketDataUser"/>
+   marketDataUser group is for public kline and other market data related APIs, which contains following published api.
+
+| Path | Method | Weight | Description |
+|------|--------|--------|-------------|
+| /exchange/public/md/kline | GET | 4 | kline query |
 
    * Others
 

--- a/Public-Contract-API-en.md
+++ b/Public-Contract-API-en.md
@@ -1411,6 +1411,8 @@ GET /md/orderbook?symbol=BTCUSD
 
 ### Query kline
 
+NOTE: please be noted that kline interfaces have rate limit [https://github.com/phemex/phemex-api-docs/blob/master/Generic-API-Info.en.md#rate-limits](rate limits) rule,  please check the marketDataUser group under [https://github.com/phemex/phemex-api-docs/blob/master/Generic-API-Info.en.md#api-groups](api groups) 
+
 ```
 GET /exchange/public/md/kline?symbol=<symbol>&to=<to>&from=<from>&resolution=<resolution>
 

--- a/Public-Contract-API-en.md
+++ b/Public-Contract-API-en.md
@@ -1411,7 +1411,7 @@ GET /md/orderbook?symbol=BTCUSD
 
 ### Query kline
 
-NOTE: please be noted that kline interfaces have rate limit [https://github.com/phemex/phemex-api-docs/blob/master/Generic-API-Info.en.md#rate-limits](rate limits) rule,  please check the marketDataUser group under [https://github.com/phemex/phemex-api-docs/blob/master/Generic-API-Info.en.md#api-groups](api groups) 
+NOTE: please be noted that kline interfaces have rate limit [https://github.com/phemex/phemex-api-docs/blob/master/Generic-API-Info.en.md#rate-limits](rate limits) rule,  please check the MarketData group under [https://github.com/phemex/phemex-api-docs/blob/master/Generic-API-Info.en.md#api-groups](api groups) 
 
 ```
 GET /exchange/public/md/kline?symbol=<symbol>&to=<to>&from=<from>&resolution=<resolution>


### PR DESCRIPTION
AS-769: adding marketDataUser group in Generic-API-Info.en.md
AS-769: adding throtlle checkt notes to the kline query parts